### PR TITLE
Configured render markdown on startup

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -130,10 +130,16 @@ return {
 
   {
     "MeanderingProgrammer/render-markdown.nvim",
+    cmd = { "RenderMarkdown" },
     opts = {},
     -- dependencies = { "nvim-treesitter/nvim-treesitter", "echasnovski/mini.nvim" }, -- if you use the mini.nvim suite
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.icons' }, -- if you use standalone mini plugins
-    dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
+    dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" }, -- if you prefer nvim-web-devicons
+    config = function()
+      local render_markdown = require('render-markdown')
+      render_markdown.setup({})
+      vim.api.nvim_set_keymap("n", "<leader>mr", ":RenderMarkdown toggle<CR>", { noremap = true, silent = true})
+    end,
   },
 
   {


### PR DESCRIPTION
Triggered loading with :RenderMarkdown. Then I made sure that only after the first trigger of the plugin, the rendering can be toggled on and off with <leader> + mr